### PR TITLE
Add unit tests for controller and services

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,12 @@
             <artifactId>httpclient5</artifactId>
             <version>5.2.1</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <version>${spring.boot.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/src/test/java/com/aem/mcp/client/GptServiceOldTest.java
+++ b/src/test/java/com/aem/mcp/client/GptServiceOldTest.java
@@ -1,0 +1,17 @@
+package com.aem.mcp.client;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class GptServiceOldTest {
+
+    @Test
+    public void returnsStaticQuery() {
+        GptServiceOld service = new GptServiceOld();
+        String query = service.generateJcrQuery("any question");
+        assertNotNull(query);
+        assertFalse(query.isEmpty());
+        assertTrue(query.contains("SELECT * FROM [cq:Page]"));
+    }
+}

--- a/src/test/java/com/aem/mcp/client/McpControllerTest.java
+++ b/src/test/java/com/aem/mcp/client/McpControllerTest.java
@@ -1,0 +1,33 @@
+package com.aem.mcp.client;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.http.ResponseEntity;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class McpControllerTest {
+
+    @Test
+    public void queryCombinesServices() {
+        GptService gptService = Mockito.mock(GptService.class);
+        AemQueryService aemQueryService = Mockito.mock(AemQueryService.class);
+
+        Mockito.when(gptService.generateJcrQuery("test question"))
+                .thenReturn("SELECT * FROM [cq:Page]");
+        Mockito.when(aemQueryService.runQuery("SELECT * FROM [cq:Page]"))
+                .thenReturn("[\"/content/page1\"]");
+
+        McpController controller = new McpController(gptService, aemQueryService);
+
+        ResponseEntity<String> response = controller.query(Map.of("question", "test question"));
+
+        assertEquals(200, response.getStatusCodeValue());
+        assertNotNull(response.getBody());
+        assertTrue(response.getBody().contains("\"query\""));
+        assertTrue(response.getBody().contains("\"data\""));
+        assertTrue(response.getBody().contains("SELECT * FROM [cq:Page]"));
+    }
+}


### PR DESCRIPTION
## Summary
- add spring-boot-starter-test dependency
- add tests for `McpController` and `GptServiceOld`

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6850140585a0832cb6575d788689573a