### PR TITLE
Add service to produce form combinations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,12 @@
             <artifactId>httpclient5</artifactId>
             <version>5.2.1</version>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.9.3</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -37,6 +43,11 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <version>${spring.boot.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/com/aem/mcp/client/CombinationService.java
+++ b/src/main/java/com/aem/mcp/client/CombinationService.java
@@ -1,0 +1,66 @@
+package com.aem.mcp.client;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.util.*;
+
+/**
+ * Service that expands JSON form definitions with select options into all valid combinations.
+ */
+@Service
+public class CombinationService {
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    /**
+     * Parses the supplied JSON string and returns every valid combination of select options.
+     * Static values are preserved and blank options are skipped.
+     */
+    public List<Map<String, String>> generateCombinations(String json) throws IOException {
+        JsonNode root = mapper.readTree(json);
+        Map<String, List<String>> fieldOptions = new LinkedHashMap<>();
+        collectOptions(root, fieldOptions);
+        List<Map.Entry<String, List<String>>> entries = new ArrayList<>(fieldOptions.entrySet());
+        List<Map<String, String>> result = new ArrayList<>();
+        build(entries, 0, new LinkedHashMap<>(), result);
+        return result;
+    }
+
+    private void collectOptions(JsonNode node, Map<String, List<String>> map) {
+        if (!node.isObject()) {
+            return;
+        }
+        node.fields().forEachRemaining(entry -> {
+            JsonNode value = entry.getValue();
+            if (value.isArray()) {
+                List<String> vals = new ArrayList<>();
+                value.forEach(v -> {
+                    String s = v.asText();
+                    if (s != null && !s.trim().isEmpty()) {
+                        vals.add(s);
+                    }
+                });
+                map.put(entry.getKey(), vals);
+            } else if (value.isValueNode()) {
+                map.put(entry.getKey(), Collections.singletonList(value.asText()));
+            } else if (value.isObject()) {
+                collectOptions(value, map);
+            }
+        });
+    }
+
+    private void build(List<Map.Entry<String, List<String>>> entries, int index,
+                       Map<String, String> current, List<Map<String, String>> result) {
+        if (index == entries.size()) {
+            result.add(new LinkedHashMap<>(current));
+            return;
+        }
+        Map.Entry<String, List<String>> entry = entries.get(index);
+        for (String val : entry.getValue()) {
+            current.put(entry.getKey(), val);
+            build(entries, index + 1, current, result);
+        }
+    }
+}

--- a/src/test/java/com/aem/mcp/client/CombinationServiceTest.java
+++ b/src/test/java/com/aem/mcp/client/CombinationServiceTest.java
@@ -1,0 +1,44 @@
+package com.aem.mcp.client;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class CombinationServiceTest {
+    @Test
+    void generatesAllCombinations() throws IOException {
+        String json = """
+        {
+          \"properties\": {
+            \"properties/columns/column/labelDistancelabelDistance\": \"20\",
+            \"properties/columns/column/sectionssections\": \"2\",
+            \"properties/columns/column/legendLayout/decimaldecimal\": \"true\",
+            \"properties/columns/column/legendLayout/decimalPlacesdecimalPlaces\": [\"1\", \"2\", \"0\"]
+          },
+          \"asset\": {
+            \"asset/columns/column/dataFiledataFile\": \"true\",
+            \"asset/columns/column/overrideoverride\": \"true\",
+            \"asset/columns/column/container/well/variantvariant\": [\"default\", \"target\", \"subdivided\"],
+            \"asset/columns/column/container/well/valuevalue\": \"true\",
+            \"asset/columns/column/container/well/targettarget\": \"true\",
+            \"asset/columns/column/container/well/minmin\": \"true\",
+            \"asset/columns/column/container/well/maxmax\": \"true\"
+          },
+          \"performance\": {
+            \"performance/columns/column/deferDefinedDisableddeferDefinedDisabled\": \"true\"
+          },
+          \"style\": {
+            \"style/columns/modemode\": [\"\", \"beacon-on-light\", \"beacon-on-lighter\", \"beacon-on-dark\", \"beacon-on-darker\"],
+            \"style/columns/motionmotion\": [\"\", \"disabled\", \"enabled\"]
+          }
+        }
+        """;
+        CombinationService service = new CombinationService();
+        List<Map<String, String>> combos = service.generateCombinations(json);
+        assertEquals(72, combos.size());
+    }
+}


### PR DESCRIPTION
## Summary
- implement `CombinationService` to expand JSON form options into every possible combination
- add unit test for combination generation
- add JUnit dependency and surefire plugin

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:2.6 or one of its dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68754e92285c832c84a76db0772db47a